### PR TITLE
Removed highlighting of hyperlinks

### DIFF
--- a/text/ads/header.tex
+++ b/text/ads/header.tex
@@ -76,15 +76,15 @@
 \author{\defAutor}
 \date{\defAbgabedatum}
 
-\usepackage[%
+\usepackage[
+    \ifdefined\defHideLinkBorders pdfborder={0 0 0},\fi
     pdftitle={\defTitel},
     pdfauthor={\defAutor},
     pdfsubject={\defArbeit},
     pdfcreator={pdflatex, LaTeX with KOMA-Script},
     pdfpagemode=UseOutlines,
     pdfdisplaydoctitle=true, 
-    pdflang={de},
-    pdfborder={0 0 0}
+    pdflang={de}
 ]{hyperref}
 
 \hypersetup{%

--- a/text/ads/header.tex
+++ b/text/ads/header.tex
@@ -77,7 +77,7 @@
 \date{\defAbgabedatum}
 
 \usepackage[
-    \ifdefined\defHideLinkBorders pdfborder={0 0 0},\fi
+    \ifdefined\defShowLinkBorders pdfborder={0 0 1}, \else pdfborder={0 0 0},\fi
     pdftitle={\defTitel},
     pdfauthor={\defAutor},
     pdfsubject={\defArbeit},

--- a/text/ads/header.tex
+++ b/text/ads/header.tex
@@ -83,7 +83,8 @@
     pdfcreator={pdflatex, LaTeX with KOMA-Script},
     pdfpagemode=UseOutlines,
     pdfdisplaydoctitle=true, 
-    pdflang={de}
+    pdflang={de},
+    pdfborder={0 0 0}
 ]{hyperref}
 
 \hypersetup{%

--- a/text/dokumentation.tex
+++ b/text/dokumentation.tex
@@ -25,8 +25,8 @@
 % Folgende Zeile auskommentieren, um alle Quellenangaben im Literaturverzeichnis anzuzeigen. 
 % \newcommand{\defAlleQuellenZeigen}
 
-% Folgende Zeile auskommentieren, um die bunten Rahmen um Hyperlinks, Referenzen etc. anzuzeigen
-\newcommand{\defHideLinkBorders}
+% Folgende Zeile auskommentieren, um die bunten Rahmen um Hyperlinks, Referenzen etc. auszublenden
+\newcommand{\defShowLinkBorders}
 
 % +------------------------------------+
 % |  Ende des Konfigurationsbereiches  |

--- a/text/dokumentation.tex
+++ b/text/dokumentation.tex
@@ -25,6 +25,9 @@
 % Folgende Zeile auskommentieren, um alle Quellenangaben im Literaturverzeichnis anzuzeigen. 
 % \newcommand{\defAlleQuellenZeigen}
 
+% Folgende Zeile auskommentieren, um die bunten Rahmen um Hyperlinks, Referenzen etc. anzuzeigen
+\newcommand{\defHideLinkBorders}
+
 % +------------------------------------+
 % |  Ende des Konfigurationsbereiches  |
 % +------------------------------------+


### PR DESCRIPTION
The attribute "pdfborder" removes the red border of the hyperlinks in the documentation